### PR TITLE
fixed bug details on Loader when apply react-transition-group library

### DIFF
--- a/src/components/WrittenBy/WrittenBy.js
+++ b/src/components/WrittenBy/WrittenBy.js
@@ -4,8 +4,8 @@ import classes from './WrittenBy.module.css';
 const WrittenBy = (props) => {
 
   return (
-    <p className={classes.WrittenBy}>Written by <a href='https://www.youtube.com/watch?v=m7Bc3pLyij0'>Joseph Arrieta</a> 
-    <a href={props.link} target="_blank" rel="noopener noreferrer" >{props.author}</a> on {props.date}</p>
+    <p className={classes.WrittenBy}>Written by <a href='https://www.youtube.com/watch?v=m7Bc3pLyij0'>Joseph Arrieta</a>
+     <a href={props.link} target="_blank" rel="noopener noreferrer" >{props.author}</a> on {props.date}</p>
   );
 };
 

--- a/src/containers/MainBody/MainBody.module.css
+++ b/src/containers/MainBody/MainBody.module.css
@@ -17,6 +17,6 @@
     display: flex;
     position: absolute;
     align-items: center;
-    margin-left: 35em;
-    margin-top: 12em;
+    margin-left: 400px;
+    margin-top: 50px;
 }


### PR DESCRIPTION
* When I apply the react-transition-group Library loader move  from it original position but now that is solved.

![image](https://user-images.githubusercontent.com/57842910/90073566-70f61700-dcc7-11ea-854f-0bd662f959f5.png)



![image](https://user-images.githubusercontent.com/57842910/90073713-b31f5880-dcc7-11ea-9bfe-831d1b5597bf.png)


* Also fixed code smeel on WritenBy Component